### PR TITLE
Tweak some style things/cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,11 +109,11 @@ async function watchContract(network, contractAddress, type, timeout, state) {
         const makeOvenOperation = operations.find(o => o.entrypoint === 'makeOven')
         // If we did not receive the makeOven call in our set of operations
         // then make an explicit call to the store of that contract for ovenOwner
-        if (makeOvenOperation !== undefined) {
-          ovenOwner = makeOvenOperation.source
-        } else {
+        if (makeOvenOperation === undefined) {
           const storageResponse = await betterCallDevAxios.get(`https://api.better-call.dev/v1/contract/${network}/${contractAddress}/storage`)
           ovenOwner = storageResponse.data[0].children.filter(o => o.name === "owner").value
+        } else {
+          ovenOwner = makeOvenOperation.source
         }
         state = { ovenOwner }
       } else {

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ async function watchContract(network, contractAddress, type, timeout, state) {
           const storageResponse = await betterCallDevAxios.get(`https://api.better-call.dev/v1/contract/${network}/${contractAddress}/storage`)
           ovenOwner = storageResponse.data[0].children.filter(o => o.name === "owner").value
         }
-        state = { ovenOwner };
+        state = { ovenOwner }
       } else {
         state = {}
       }
@@ -127,7 +127,7 @@ async function watchContract(network, contractAddress, type, timeout, state) {
         // Skip duplicate origination notification on Oven contracts (should never actually happen)
         if (operation.entrypoint === 'makeOven' && type === CONTRACT_TYPES.Oven) { continue }
         // Ignore calls to default entrypoint if it is not made by the originator of the oven (likely baker sending rewards)
-        if (operation.entrypoint === "default" && state.ovenOwner !== operation.source) { continue; }
+        if (operation.entrypoint === "default" && state.ovenOwner !== operation.source) { continue }
 
         await processNewOperation(operation, type)
       }


### PR DESCRIPTION
This PR makes a few changes to #4, mostly around style and readability.

Changes:
- Remove semi-colons - newer versions of JS don't need them, and files should either all use them strictly or never use them IMO (I was an offender of this myself lol)
- Put spaces between `//` and the comment, makes things more readable
- Put spaces between `if` and `(`, which is more readable/in-line with the rest of the code 
- Prefer `!==` instead of a pattern like `if(!(type === CONTRACT_TYPES.OvenFactory))`
- Use a more descriptive `makeOvenOperation` instead of `makeOven`, since it wasn't immediately obvious what it was (to my eye)
- Use `makeOvenOperation === undefined` instead of just `!makeOven` (or `!makeOvenOperation`). Depending on loose typing in JS for things like this sometimes introduces weird bugs, better to be explicit (find will return `undefined` if a match isn't found)
- `response` was actually being shadowed from the call on line 97, which can cause some weirdness. Not sure if you're using an IDE but I highly recommend Webstorm since it makes things like this obvious and easy to catch (not sure VSCode does). Renamed to `storageResponse`
- Re-tooled things to move away from the pattern matching type of stuff on line 113, it's fragile and just using `.value` sometimes is the easiest/cleanest way.
- Removed some un-necessary parenthesis in the arrow function - if there's only one argument (or only one you care about) you don't need them